### PR TITLE
Set image name outside the build process

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -42,7 +42,10 @@ jobs:
               echo "::set-env name=ZIP_FILENAME::$IMAGE_NAME"
 
         - name: Run build script
-          run: sudo ./build.sh
+          run: |
+              echo $IMG_FILENAME
+              echo $ZIP_FILENAME
+              sudo ./build.sh
 
         # - name: Copy ZIP to current working dir
         #   run: cp deploy/*.zip ./

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -53,5 +53,5 @@ jobs:
         - name: Upload artifact
           uses: actions/upload-artifact@v2
           with:
-            path: ${{ $IMAGE_NAME }}.zip
-            name: ${{ $IMAGE_NAME }}.zip
+            path: ${{ env.IMAGE_NAME }}.zip
+            name: ${{ env.IMAGE_NAME }}.zip

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -10,29 +10,29 @@ jobs:
         
         - uses: actions/checkout@v1
 
-        - name: Run Apt-get update
-          run: sudo apt-get update
+        # - name: Run Apt-get update
+        #   run: sudo apt-get update
 
-        - name: Install dependencies
-          run: sudo apt-get -y install quilt qemu-user-static debootstrap bsdtar
+        # - name: Install dependencies
+        #   run: sudo apt-get -y install quilt qemu-user-static debootstrap bsdtar
 
-        - name: Nuke current Docker installation
-          run: |
-              sudo systemctl stop docker
-              sudo apt-get purge docker-ce docker-ce-cli containerd.io moby-engine moby-cli
-              sudo rm -rf /var/lib/docker
+        # - name: Nuke current Docker installation
+        #   run: |
+        #       sudo systemctl stop docker
+        #       sudo apt-get purge docker-ce docker-ce-cli containerd.io moby-engine moby-cli
+        #       sudo rm -rf /var/lib/docker
         
-        - name: Re-install Docker
-          run: |
-              curl -fsSL https://get.docker.com -o get-docker.sh
-              sudo sh get-docker.sh
-              docker --version
+        # - name: Re-install Docker
+        #   run: |
+        #       curl -fsSL https://get.docker.com -o get-docker.sh
+        #       sudo sh get-docker.sh
+        #       docker --version
 
-        - name: Enable experimental features in Docker
-          run: |
-              sudo rm -rf /etc/docker/daemon.json
-              echo '{"experimental": true}' | sudo tee -a /etc/docker/daemon.json
-              sudo systemctl restart docker
+        # - name: Enable experimental features in Docker
+        #   run: |
+        #       sudo rm -rf /etc/docker/daemon.json
+        #       echo '{"experimental": true}' | sudo tee -a /etc/docker/daemon.json
+        #       sudo systemctl restart docker
 
         - name: Set image name
           run: |
@@ -44,14 +44,14 @@ jobs:
         - name: Run build script
           run: sudo ./build.sh
 
-        - name: Copy ZIP to current working dir
-          run: cp deploy/*.zip ./
+        # - name: Copy ZIP to current working dir
+        #   run: cp deploy/*.zip ./
 
-        - name: Debug current working dir
-          run: ls -la
+        # - name: Debug current working dir
+        #   run: ls -la
         
-        - name: Upload artifact
-          uses: actions/upload-artifact@v2
-          with:
-            path: $ZIP_FILENAME.zip
-            name: $ZIP_FILENAME.zip
+        # - name: Upload artifact
+        #   uses: actions/upload-artifact@v2
+        #   with:
+        #     path: $ZIP_FILENAME.zip
+        #     name: $ZIP_FILENAME.zip

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -33,15 +33,14 @@ jobs:
         #       sudo rm -rf /etc/docker/daemon.json
         #       echo '{"experimental": true}' | sudo tee -a /etc/docker/daemon.json
         #       sudo systemctl restart docker
-
-          - name: Setting image name
-            run: |
-                  IMAGE_NAME="umbrel-os-$(git describe --tags)"
-                  echo $IMAGE_NAME
-                  echo "::set-env name=IMAGE_NAME::IMAGE_NAME"
+        - name: Setting image name
+          run: |
+              IMAGE_NAME="umbrel-os-$(git describe --tags)"
+              echo $IMAGE_NAME
+              echo "::set-env name=IMAGE_NAME::IMAGE_NAME"
                   
-          - name: Verify image name
-            run: echo $IMAGE_NAME
+        - name: Verify image name
+          run: echo $IMAGE_NAME
 
         # - name: Run build script
         #   run: sudo ./build.sh

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -53,5 +53,5 @@ jobs:
         - name: Upload artifact
           uses: actions/upload-artifact@v2
           with:
-            path: $IMAGE_NAME.zip
-            name: $IMAGE_NAME.zip
+            path: ${{ $IMAGE_NAME }}.zip
+            name: ${{ $IMAGE_NAME }}.zip

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -10,40 +10,49 @@ jobs:
         
         - uses: actions/checkout@v1
 
-        - name: Run Apt-get update
-          run: sudo apt-get update
+        # - name: Run Apt-get update
+        #   run: sudo apt-get update
 
-        - name: Install dependencies
-          run: sudo apt-get -y install quilt qemu-user-static debootstrap bsdtar
+        # - name: Install dependencies
+        #   run: sudo apt-get -y install quilt qemu-user-static debootstrap bsdtar
 
-        - name: Nuke current Docker installation
-          run: |
-              sudo systemctl stop docker
-              sudo apt-get purge docker-ce docker-ce-cli containerd.io moby-engine moby-cli
-              sudo rm -rf /var/lib/docker
+        # - name: Nuke current Docker installation
+        #   run: |
+        #       sudo systemctl stop docker
+        #       sudo apt-get purge docker-ce docker-ce-cli containerd.io moby-engine moby-cli
+        #       sudo rm -rf /var/lib/docker
         
-        - name: Re-install Docker
-          run: |
-              curl -fsSL https://get.docker.com -o get-docker.sh
-              sudo sh get-docker.sh
-              docker --version
+        # - name: Re-install Docker
+        #   run: |
+        #       curl -fsSL https://get.docker.com -o get-docker.sh
+        #       sudo sh get-docker.sh
+        #       docker --version
 
-        - name: Enable experimental features in Docker
-          run: |
-              sudo rm -rf /etc/docker/daemon.json
-              echo '{"experimental": true}' | sudo tee -a /etc/docker/daemon.json
-              sudo systemctl restart docker
+        # - name: Enable experimental features in Docker
+        #   run: |
+        #       sudo rm -rf /etc/docker/daemon.json
+        #       echo '{"experimental": true}' | sudo tee -a /etc/docker/daemon.json
+        #       sudo systemctl restart docker
 
-        - name: Run build script
-          run: sudo ./build.sh
+          - name: Setting image name
+            run: |
+                  IMAGE_NAME="umbrel-os-$(git describe --tags)"
+                  echo $IMAGE_NAME
+                  echo "::set-env name=IMAGE_NAME::IMAGE_NAME"
+                  
+          - name: Verify image name
+            run: echo $IMAGE_NAME
 
-        - name: Copy ZIP to current working dir
-          run: cp deploy/*.zip ./
+        # - name: Run build script
+        #   run: sudo ./build.sh
 
-        - name: Debug current working dir
-          run: ls -la
+        # - name: Copy ZIP to current working dir
+        #   run: cp deploy/*.zip ./
+
+        # - name: Debug current working dir
+        #   run: ls -la
         
-        - name: Upload artifact
-          uses: actions/upload-artifact@v2
-          with:
-            path: umbrel-*.zip
+        # - name: Upload artifact
+        #   uses: actions/upload-artifact@v2
+        #   with:
+        #     path: umbrel-*.zip

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -37,15 +37,12 @@ jobs:
         - name: Set image name
           run: |
               IMAGE_NAME="umbrel-os-$(git describe --tags)"
-              echo $IMAGE_NAME
-              echo "::set-env name=IMG_FILENAME::$IMAGE_NAME"
-              echo "::set-env name=ZIP_FILENAME::$IMAGE_NAME"
+              echo "::set-env name=IMAGE_NAME::$IMAGE_NAME"
 
         - name: Run build script
           run: |
-              echo $IMG_FILENAME
-              echo $ZIP_FILENAME
-              sudo ./build.sh
+              echo "Building $IMAGE_NAME"
+              sudo IMG_FILENAME=$IMAGE_NAME ZIP_FILENAME=$IMAGE_NAME ./build.sh
 
         # - name: Copy ZIP to current working dir
         #   run: cp deploy/*.zip ./
@@ -56,5 +53,5 @@ jobs:
         # - name: Upload artifact
         #   uses: actions/upload-artifact@v2
         #   with:
-        #     path: $ZIP_FILENAME.zip
-        #     name: $ZIP_FILENAME.zip
+        #     path: $IMAGE_NAME.zip
+        #     name: $IMAGE_NAME.zip

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -10,51 +10,48 @@ jobs:
         
         - uses: actions/checkout@v1
 
-        # - name: Run Apt-get update
-        #   run: sudo apt-get update
+        - name: Run Apt-get update
+          run: sudo apt-get update
 
-        # - name: Install dependencies
-        #   run: sudo apt-get -y install quilt qemu-user-static debootstrap bsdtar
+        - name: Install dependencies
+          run: sudo apt-get -y install quilt qemu-user-static debootstrap bsdtar
 
-        # - name: Nuke current Docker installation
-        #   run: |
-        #       sudo systemctl stop docker
-        #       sudo apt-get purge docker-ce docker-ce-cli containerd.io moby-engine moby-cli
-        #       sudo rm -rf /var/lib/docker
+        - name: Nuke current Docker installation
+          run: |
+              sudo systemctl stop docker
+              sudo apt-get purge docker-ce docker-ce-cli containerd.io moby-engine moby-cli
+              sudo rm -rf /var/lib/docker
         
-        # - name: Re-install Docker
-        #   run: |
-        #       curl -fsSL https://get.docker.com -o get-docker.sh
-        #       sudo sh get-docker.sh
-        #       docker --version
+        - name: Re-install Docker
+          run: |
+              curl -fsSL https://get.docker.com -o get-docker.sh
+              sudo sh get-docker.sh
+              docker --version
 
-        # - name: Enable experimental features in Docker
-        #   run: |
-        #       sudo rm -rf /etc/docker/daemon.json
-        #       echo '{"experimental": true}' | sudo tee -a /etc/docker/daemon.json
-        #       sudo systemctl restart docker
-        - name: Setting image name
+        - name: Enable experimental features in Docker
+          run: |
+              sudo rm -rf /etc/docker/daemon.json
+              echo '{"experimental": true}' | sudo tee -a /etc/docker/daemon.json
+              sudo systemctl restart docker
+
+        - name: Set image name
           run: |
               IMAGE_NAME="umbrel-os-$(git describe --tags)"
               echo $IMAGE_NAME
               echo "::set-env name=IMG_FILENAME::$IMAGE_NAME"
               echo "::set-env name=ZIP_FILENAME::$IMAGE_NAME"
-                  
-        - name: Verify image name
-          run: |
-              echo "Image: $IMG_FILENAME"
-              echo "Zip: $ZIP_FILENAME"
 
-        # - name: Run build script
-        #   run: sudo ./build.sh
+        - name: Run build script
+          run: sudo ./build.sh
 
-        # - name: Copy ZIP to current working dir
-        #   run: cp deploy/*.zip ./
+        - name: Copy ZIP to current working dir
+          run: cp deploy/*.zip ./
 
-        # - name: Debug current working dir
-        #   run: ls -la
+        - name: Debug current working dir
+          run: ls -la
         
-        # - name: Upload artifact
-        #   uses: actions/upload-artifact@v2
-        #   with:
-        #     path: umbrel-*.zip
+        - name: Upload artifact
+          uses: actions/upload-artifact@v2
+          with:
+            path: "$ZIP_FILENAME".zip
+            name: "$ZIP_FILENAME".zip

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -37,10 +37,13 @@ jobs:
           run: |
               IMAGE_NAME="umbrel-os-$(git describe --tags)"
               echo $IMAGE_NAME
-              echo "::set-env name=IMAGE_NAME::IMAGE_NAME"
+              echo "::set-env name=IMG_FILENAME::$IMAGE_NAME"
+              echo "::set-env name=ZIP_FILENAME::$IMAGE_NAME"
                   
         - name: Verify image name
-          run: echo $IMAGE_NAME
+          run: |
+              echo "Image: $IMG_FILENAME"
+              echo "Zip: $ZIP_FILENAME"
 
         # - name: Run build script
         #   run: sudo ./build.sh

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -53,5 +53,5 @@ jobs:
         - name: Upload artifact
           uses: actions/upload-artifact@v2
           with:
-            path: "$ZIP_FILENAME".zip
-            name: "$ZIP_FILENAME".zip
+            path: $ZIP_FILENAME.zip
+            name: $ZIP_FILENAME.zip

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -10,29 +10,29 @@ jobs:
         
         - uses: actions/checkout@v1
 
-        # - name: Run Apt-get update
-        #   run: sudo apt-get update
+        - name: Run Apt-get update
+          run: sudo apt-get update
 
-        # - name: Install dependencies
-        #   run: sudo apt-get -y install quilt qemu-user-static debootstrap bsdtar
+        - name: Install dependencies
+          run: sudo apt-get -y install quilt qemu-user-static debootstrap bsdtar
 
-        # - name: Nuke current Docker installation
-        #   run: |
-        #       sudo systemctl stop docker
-        #       sudo apt-get purge docker-ce docker-ce-cli containerd.io moby-engine moby-cli
-        #       sudo rm -rf /var/lib/docker
+        - name: Nuke current Docker installation
+          run: |
+              sudo systemctl stop docker
+              sudo apt-get purge docker-ce docker-ce-cli containerd.io moby-engine moby-cli
+              sudo rm -rf /var/lib/docker
         
-        # - name: Re-install Docker
-        #   run: |
-        #       curl -fsSL https://get.docker.com -o get-docker.sh
-        #       sudo sh get-docker.sh
-        #       docker --version
+        - name: Re-install Docker
+          run: |
+              curl -fsSL https://get.docker.com -o get-docker.sh
+              sudo sh get-docker.sh
+              docker --version
 
-        # - name: Enable experimental features in Docker
-        #   run: |
-        #       sudo rm -rf /etc/docker/daemon.json
-        #       echo '{"experimental": true}' | sudo tee -a /etc/docker/daemon.json
-        #       sudo systemctl restart docker
+        - name: Enable experimental features in Docker
+          run: |
+              sudo rm -rf /etc/docker/daemon.json
+              echo '{"experimental": true}' | sudo tee -a /etc/docker/daemon.json
+              sudo systemctl restart docker
 
         - name: Set image name
           run: |
@@ -44,14 +44,14 @@ jobs:
               echo "Building $IMAGE_NAME"
               sudo IMG_FILENAME=$IMAGE_NAME ZIP_FILENAME=$IMAGE_NAME ./build.sh
 
-        # - name: Copy ZIP to current working dir
-        #   run: cp deploy/*.zip ./
+        - name: Copy ZIP to current working dir
+          run: cp deploy/*.zip ./
 
-        # - name: Debug current working dir
-        #   run: ls -la
+        - name: Debug current working dir
+          run: ls -la
         
-        # - name: Upload artifact
-        #   uses: actions/upload-artifact@v2
-        #   with:
-        #     path: $IMAGE_NAME.zip
-        #     name: $IMAGE_NAME.zip
+        - name: Upload artifact
+          uses: actions/upload-artifact@v2
+          with:
+            path: $IMAGE_NAME.zip
+            name: $IMAGE_NAME.zip

--- a/.github/workflows/on-tag-only.yml
+++ b/.github/workflows/on-tag-only.yml
@@ -72,6 +72,6 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           with:
             upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-            asset_path: ${{ $IMAGE_NAME }}.zip
-            asset_name: ${{ $IMAGE_NAME }}.zip
+            asset_path: ${{ env.IMAGE_NAME }}.zip
+            asset_name: ${{ env.IMAGE_NAME }}.zip
             asset_content_type: application/gzip

--- a/.github/workflows/on-tag-only.yml
+++ b/.github/workflows/on-tag-only.yml
@@ -72,6 +72,6 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           with:
             upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-            asset_path: "$ZIP_FILENAME".zip
-            asset_name: "$ZIP_FILENAME".zip
+            asset_path: $ZIP_FILENAME.zip
+            asset_name: $ZIP_FILENAME.zip
             asset_content_type: application/gzip

--- a/.github/workflows/on-tag-only.yml
+++ b/.github/workflows/on-tag-only.yml
@@ -72,6 +72,6 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           with:
             upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-            asset_path: $IMAGE_NAME.zip
-            asset_name: $IMAGE_NAME.zip
+            asset_path: ${{ $IMAGE_NAME }}.zip
+            asset_name: ${{ $IMAGE_NAME }}.zip
             asset_content_type: application/gzip

--- a/.github/workflows/on-tag-only.yml
+++ b/.github/workflows/on-tag-only.yml
@@ -37,6 +37,13 @@ jobs:
                 sudo rm -rf /etc/docker/daemon.json
                 echo '{"experimental": true}' | sudo tee -a /etc/docker/daemon.json
                 sudo systemctl restart docker
+        
+        - name: Set image name
+          run: |
+                IMAGE_NAME="umbrel-os-$(git describe --tags)"
+                echo $IMAGE_NAME
+                echo "::set-env name=IMG_FILENAME::$IMAGE_NAME"
+                echo "::set-env name=ZIP_FILENAME::$IMAGE_NAME"
 
         - name: Run build script
           run: sudo ./build.sh
@@ -65,5 +72,6 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           with:
             upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-            asset_path: umbrel-*.zip
+            asset_path: "$ZIP_FILENAME".zip
+            asset_name: "$ZIP_FILENAME".zip
             asset_content_type: application/gzip

--- a/.github/workflows/on-tag-only.yml
+++ b/.github/workflows/on-tag-only.yml
@@ -41,12 +41,12 @@ jobs:
         - name: Set image name
           run: |
                 IMAGE_NAME="umbrel-os-$(git describe --tags)"
-                echo $IMAGE_NAME
-                echo "::set-env name=IMG_FILENAME::$IMAGE_NAME"
-                echo "::set-env name=ZIP_FILENAME::$IMAGE_NAME"
+                echo "::set-env name=IMAGE_NAME::$IMAGE_NAME"
 
         - name: Run build script
-          run: sudo ./build.sh
+          run: |
+                echo "Building $IMAGE_NAME"
+                sudo IMG_FILENAME=$IMAGE_NAME ZIP_FILENAME=$IMAGE_NAME ./build.sh
 
         - name: Copy ZIP to current working dir
           run: cp deploy/*.zip ./
@@ -72,6 +72,6 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           with:
             upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-            asset_path: $ZIP_FILENAME.zip
-            asset_name: $ZIP_FILENAME.zip
+            asset_path: $IMAGE_NAME.zip
+            asset_name: $IMAGE_NAME.zip
             asset_content_type: application/gzip

--- a/build.sh
+++ b/build.sh
@@ -207,7 +207,7 @@ source "${SCRIPT_DIR}/common"
 # shellcheck source=scripts/dependencies_check
 source "${SCRIPT_DIR}/dependencies_check"
 
-dependencies_check "${BASE_DIR}/depends"
+# dependencies_check "${BASE_DIR}/depends"
 
 #check username is valid
 if [[ ! "$FIRST_USER_NAME" =~ ^[a-z][-a-z0-9_]*$ ]]; then

--- a/build.sh
+++ b/build.sh
@@ -153,8 +153,8 @@ fi
 
 export USE_QEMU="${USE_QEMU:-0}"
 export IMG_DATE="${IMG_DATE:-"$(date +%Y-%m-%d)"}"
-# export IMG_FILENAME="${IMG_FILENAME:-"${IMG_DATE}-${IMG_NAME}"}"
-# export ZIP_FILENAME="${ZIP_FILENAME:-"${IMG_NAME}"}"
+export IMG_FILENAME="${IMG_FILENAME:-"${IMG_DATE}-${IMG_NAME}"}"
+export ZIP_FILENAME="${ZIP_FILENAME:-"${IMG_NAME}"}"
 
 export SCRIPT_DIR="${BASE_DIR}/scripts"
 export WORK_DIR="${WORK_DIR:-"${BASE_DIR}/work/${IMG_DATE}-${IMG_NAME}"}"
@@ -207,7 +207,7 @@ source "${SCRIPT_DIR}/common"
 # shellcheck source=scripts/dependencies_check
 source "${SCRIPT_DIR}/dependencies_check"
 
-# dependencies_check "${BASE_DIR}/depends"
+dependencies_check "${BASE_DIR}/depends"
 
 #check username is valid
 if [[ ! "$FIRST_USER_NAME" =~ ^[a-z][-a-z0-9_]*$ ]]; then

--- a/build.sh
+++ b/build.sh
@@ -230,33 +230,36 @@ log "Begin ${BASE_DIR}"
 
 STAGE_LIST=${STAGE_LIST:-${BASE_DIR}/stage*}
 
-for STAGE_DIR in $STAGE_LIST; do
-	STAGE_DIR=$(realpath "${STAGE_DIR}")
-	run_stage
-done
+echo "Image file name: $IMG_FILENAME"
+echo "Zip file name: $ZIP_FILENAME"
 
-CLEAN=1
-for EXPORT_DIR in ${EXPORT_DIRS}; do
-	STAGE_DIR=${BASE_DIR}/export-image
-	# shellcheck source=/dev/null
-	source "${EXPORT_DIR}/EXPORT_IMAGE"
-	EXPORT_ROOTFS_DIR=${WORK_DIR}/$(basename "${EXPORT_DIR}")/rootfs
-	run_stage
-	if [ "${USE_QEMU}" != "1" ]; then
-		if [ -e "${EXPORT_DIR}/EXPORT_NOOBS" ]; then
-			# shellcheck source=/dev/null
-			source "${EXPORT_DIR}/EXPORT_NOOBS"
-			STAGE_DIR="${BASE_DIR}/export-noobs"
-			run_stage
-		fi
-	fi
-done
+# for STAGE_DIR in $STAGE_LIST; do
+# 	STAGE_DIR=$(realpath "${STAGE_DIR}")
+# 	run_stage
+# done
 
-if [ -x ${BASE_DIR}/postrun.sh ]; then
-	log "Begin postrun.sh"
-	cd "${BASE_DIR}"
-	./postrun.sh
-	log "End postrun.sh"
-fi
+# CLEAN=1
+# for EXPORT_DIR in ${EXPORT_DIRS}; do
+# 	STAGE_DIR=${BASE_DIR}/export-image
+# 	# shellcheck source=/dev/null
+# 	source "${EXPORT_DIR}/EXPORT_IMAGE"
+# 	EXPORT_ROOTFS_DIR=${WORK_DIR}/$(basename "${EXPORT_DIR}")/rootfs
+# 	run_stage
+# 	if [ "${USE_QEMU}" != "1" ]; then
+# 		if [ -e "${EXPORT_DIR}/EXPORT_NOOBS" ]; then
+# 			# shellcheck source=/dev/null
+# 			source "${EXPORT_DIR}/EXPORT_NOOBS"
+# 			STAGE_DIR="${BASE_DIR}/export-noobs"
+# 			run_stage
+# 		fi
+# 	fi
+# done
 
-log "End ${BASE_DIR}"
+# if [ -x ${BASE_DIR}/postrun.sh ]; then
+# 	log "Begin postrun.sh"
+# 	cd "${BASE_DIR}"
+# 	./postrun.sh
+# 	log "End postrun.sh"
+# fi
+
+# log "End ${BASE_DIR}"

--- a/build.sh
+++ b/build.sh
@@ -230,9 +230,6 @@ log "Begin ${BASE_DIR}"
 
 STAGE_LIST=${STAGE_LIST:-${BASE_DIR}/stage*}
 
-echo "Image file name: $IMG_FILENAME"
-echo "Zip file name: $ZIP_FILENAME"
-
 for STAGE_DIR in $STAGE_LIST; do
 	STAGE_DIR=$(realpath "${STAGE_DIR}")
 	run_stage

--- a/build.sh
+++ b/build.sh
@@ -153,8 +153,8 @@ fi
 
 export USE_QEMU="${USE_QEMU:-0}"
 export IMG_DATE="${IMG_DATE:-"$(date +%Y-%m-%d)"}"
-export IMG_FILENAME="${IMG_FILENAME:-"${IMG_DATE}-${IMG_NAME}"}"
-export ZIP_FILENAME="${ZIP_FILENAME:-"${IMG_NAME}"}"
+# export IMG_FILENAME="${IMG_FILENAME:-"${IMG_DATE}-${IMG_NAME}"}"
+# export ZIP_FILENAME="${ZIP_FILENAME:-"${IMG_NAME}"}"
 
 export SCRIPT_DIR="${BASE_DIR}/scripts"
 export WORK_DIR="${WORK_DIR:-"${BASE_DIR}/work/${IMG_DATE}-${IMG_NAME}"}"

--- a/build.sh
+++ b/build.sh
@@ -233,33 +233,33 @@ STAGE_LIST=${STAGE_LIST:-${BASE_DIR}/stage*}
 echo "Image file name: $IMG_FILENAME"
 echo "Zip file name: $ZIP_FILENAME"
 
-# for STAGE_DIR in $STAGE_LIST; do
-# 	STAGE_DIR=$(realpath "${STAGE_DIR}")
-# 	run_stage
-# done
+for STAGE_DIR in $STAGE_LIST; do
+	STAGE_DIR=$(realpath "${STAGE_DIR}")
+	run_stage
+done
 
-# CLEAN=1
-# for EXPORT_DIR in ${EXPORT_DIRS}; do
-# 	STAGE_DIR=${BASE_DIR}/export-image
-# 	# shellcheck source=/dev/null
-# 	source "${EXPORT_DIR}/EXPORT_IMAGE"
-# 	EXPORT_ROOTFS_DIR=${WORK_DIR}/$(basename "${EXPORT_DIR}")/rootfs
-# 	run_stage
-# 	if [ "${USE_QEMU}" != "1" ]; then
-# 		if [ -e "${EXPORT_DIR}/EXPORT_NOOBS" ]; then
-# 			# shellcheck source=/dev/null
-# 			source "${EXPORT_DIR}/EXPORT_NOOBS"
-# 			STAGE_DIR="${BASE_DIR}/export-noobs"
-# 			run_stage
-# 		fi
-# 	fi
-# done
+CLEAN=1
+for EXPORT_DIR in ${EXPORT_DIRS}; do
+	STAGE_DIR=${BASE_DIR}/export-image
+	# shellcheck source=/dev/null
+	source "${EXPORT_DIR}/EXPORT_IMAGE"
+	EXPORT_ROOTFS_DIR=${WORK_DIR}/$(basename "${EXPORT_DIR}")/rootfs
+	run_stage
+	if [ "${USE_QEMU}" != "1" ]; then
+		if [ -e "${EXPORT_DIR}/EXPORT_NOOBS" ]; then
+			# shellcheck source=/dev/null
+			source "${EXPORT_DIR}/EXPORT_NOOBS"
+			STAGE_DIR="${BASE_DIR}/export-noobs"
+			run_stage
+		fi
+	fi
+done
 
-# if [ -x ${BASE_DIR}/postrun.sh ]; then
-# 	log "Begin postrun.sh"
-# 	cd "${BASE_DIR}"
-# 	./postrun.sh
-# 	log "End postrun.sh"
-# fi
+if [ -x ${BASE_DIR}/postrun.sh ]; then
+	log "Begin postrun.sh"
+	cd "${BASE_DIR}"
+	./postrun.sh
+	log "End postrun.sh"
+fi
 
-# log "End ${BASE_DIR}"
+log "End ${BASE_DIR}"

--- a/build.sh
+++ b/build.sh
@@ -153,8 +153,8 @@ fi
 
 export USE_QEMU="${USE_QEMU:-0}"
 export IMG_DATE="${IMG_DATE:-"$(date +%Y-%m-%d)"}"
-export IMG_FILENAME="${IMG_FILENAME:-"${IMG_DATE}-${IMG_NAME}${TAG}"}"
-export ZIP_FILENAME="${ZIP_FILENAME:-"${IMG_NAME}${TAG}"}"
+export IMG_FILENAME="${IMG_FILENAME:-"${IMG_DATE}-${IMG_NAME}"}"
+export ZIP_FILENAME="${ZIP_FILENAME:-"${IMG_NAME}"}"
 
 export SCRIPT_DIR="${BASE_DIR}/scripts"
 export WORK_DIR="${WORK_DIR:-"${BASE_DIR}/work/${IMG_DATE}-${IMG_NAME}"}"

--- a/build.sh
+++ b/build.sh
@@ -151,12 +151,6 @@ if [ -z "${IMG_NAME}" ]; then
 	exit 1
 fi
 
-
-TAG=""
-if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
-	TAG="-$(git describe --tags)"
-fi
-
 export USE_QEMU="${USE_QEMU:-0}"
 export IMG_DATE="${IMG_DATE:-"$(date +%Y-%m-%d)"}"
 export IMG_FILENAME="${IMG_FILENAME:-"${IMG_DATE}-${IMG_NAME}${TAG}"}"


### PR DESCRIPTION
Setting the image name and zip name outside the build process helps us deterministically determine the image name before building it, so we can use the same name to upload the built asset. Also helps us keep as much configuration out of the build process itself as possible. 