### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ SSH is enabled by default and you can use the following credentials to login to 
 
 - Hostname: `umbrel.local`  
 - User: `umbrel`  
-- Password: `moneyprintergobrrr`
+- Password: `umbr3lb0x`
 
 ## 🛠 Build Umbrel OS from source
 


### PR DESCRIPTION
The ssh password is not working as documented. Saw in the Telegram group, that the default password is actually umbr3lb0x.