### PR TITLE
Fix username

### DIFF
--- a/stage2/00-sys-tweaks/01-run.sh
+++ b/stage2/00-sys-tweaks/01-run.sh
@@ -23,6 +23,8 @@ else
 	systemctl disable ssh
 fi
 systemctl enable regenerate_ssh_host_keys
+
+sed -i -e "s/\/home\/umbrel/\/home\/${FIRST_USER_NAME}/g" /etc/rc.local
 EOF
 
 if [ ! -d $ROOTFS_DIR/home/statuses ]; then

--- a/stage2/04-install-umbrel/01-run.sh
+++ b/stage2/04-install-umbrel/01-run.sh
@@ -27,6 +27,8 @@ mkdir /home/${FIRST_USER_NAME}/umbrel
 cd /home/${FIRST_USER_NAME}/umbrel
 curl -L https://github.com/getumbrel/umbrel/archive/v${UMBREL_VERSION}.tar.gz | tar -xz --strip-components=1
 chown -R ${FIRST_USER_NAME}:${FIRST_USER_NAME} /home/${FIRST_USER_NAME}
+sed -i -e "s/\/home\/umbrel/\/home\/${FIRST_USER_NAME}/g" scripts/umbrel-os/umbrel-details
+sed -i -e "s/\/home\/umbrel/\/home\/${FIRST_USER_NAME}/g" scripts/umbrel-os/services/umbrel-connection-details.service
 EOF
 
 # Bundle Umbrel's Docker images


### PR DESCRIPTION
You're sometimes using /home/umbrel instead of /home/${FIRST_USER_NAME}, but that is in files, which aren't parsed by pi-gen, but run on the final system. I think you should add a sed command in the XX-run.sh file everywhere this problem occurs, to make changing the username easier. I can also do this in a separate PR later.