### PR TITLE
Fix for build on PR/push

### DIFF
--- a/stage2/03-install-umbrel/01-run.sh
+++ b/stage2/03-install-umbrel/01-run.sh
@@ -29,7 +29,7 @@ cd /umbrel
 if [ -z ${UMBREL_REPO} ]; then
 curl -L https://github.com/getumbrel/umbrel/archive/v${UMBREL_VERSION}.tar.gz | tar -xz --strip-components=1
 else
-git clone ${UMBREL_REPO} -b "${UMBREL_BRANCH}" .
+git clone ${UMBREL_REPO} -b "${UMBREL_BRANCH}" . || git clone https://github.com/getumbrel/umbrel.git -b master .
 fi
 
 # Enable Umbrel OS systemd services


### PR DESCRIPTION
As shown in the last commit in the umbrel repo, if a PR is merged, and the branch then deleted before the check is finished, the check fails. This fixes this by cloning umbrel master if the clone fails.