### PR TITLE
Remove somme unneeded packages

### DIFF
--- a/stage2/00-sys-tweaks/00-packages
+++ b/stage2/00-sys-tweaks/00-packages
@@ -1,10 +1,8 @@
 ssh less fbset sudo psmisc strace ed ncdu crda
 console-setup keyboard-configuration debconf-utils parted unzip
-build-essential manpages-dev python bash-completion gdb pkg-config
-python-rpi.gpio v4l-utils
+manpages-dev python bash-completion pkg-config
+v4l-utils
 avahi-daemon
-lua5.1
-luajit
 hardlink ca-certificates curl
 fake-hwclock nfs-common usbutils
 libraspberrypi-dev libraspberrypi-doc libfreetype6-dev


### PR DESCRIPTION
Raspberry Pi OS contains some tools that aren't needed in Umbrel. Removing them makes the image smaller and builds faster.
Python 2 can be removed after the next EEPROM release, which will switch to Python 3.