### PR TITLE
Disable UAS for JMicron JMS578 and JMS579

### DIFF
--- a/stage1/00-boot-files/files/cmdline.txt
+++ b/stage1/00-boot-files/files/cmdline.txt
@@ -1,1 +1,1 @@
-console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait
+usb-storage.quirks=152d:1576:u,152d:0578:u console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait


### PR DESCRIPTION
JMicron's JMS578 and JMS579 are one of the most popular chipsets used in USB-to-SATA adapters, but they're still blacklisted by the kernel USB subsystem and require explicit quirk to disable UAS.

This PR adds an explicit quirk to disable UAS for both the chipsets.

Net effect:
SSD read speed before the quirk: 50-100kbps
SSD read speed after the quirk: ~200mbps (depending upon the SSD)

Further reading:
- https://github.com/raspberrypi/linux/issues/3070
- https://www.raspberrypi.org/forums/viewtopic.php?t=245931