### PR TITLE
Update existing cmdline.txt patch with the quirks

### DIFF
--- a/stage2/00-sys-tweaks/00-patches/07-resize-init.diff
+++ b/stage2/00-sys-tweaks/00-patches/07-resize-init.diff
@@ -1,5 +1,5 @@
 --- stage2.orig/rootfs/boot/cmdline.txt
 +++ stage2/rootfs/boot/cmdline.txt
 @@ -1 +1 @@
--console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait
-+console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait quiet init=/usr/lib/raspi-config/init_resize.sh
+-usb-storage.quirks=152d:1576:u,152d:0578:u console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait
++usb-storage.quirks=152d:1576:u,152d:0578:u console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait quiet init=/usr/lib/raspi-config/init_resize.sh


### PR DESCRIPTION
A bit dirty fix, ideally we should add the usb-storage quirks via a patch itself.