### PR TITLE
Remove python2

### DIFF
--- a/stage2/00-sys-tweaks/00-packages
+++ b/stage2/00-sys-tweaks/00-packages
@@ -1,10 +1,10 @@
 ssh less fbset sudo psmisc strace ed ncdu crda
 console-setup keyboard-configuration debconf-utils parted unzip
-manpages-dev python bash-completion pkg-config
+manpages-dev bash-completion pkg-config
 v4l-utils
 avahi-daemon
 hardlink ca-certificates curl
-fake-hwclock nfs-common usbutils
+fake-hwclock usbutils
 libraspberrypi-dev libraspberrypi-doc libfreetype6-dev
 dosfstools
 raspberrypi-sys-mods

--- a/stage2/00-sys-tweaks/00-packages-nr
+++ b/stage2/00-sys-tweaks/00-packages-nr
@@ -1,1 +1,2 @@
+nfs-common
 cifs-utils


### PR DESCRIPTION
The only package that still depended on python2 was rpi-eeprom, but with version 7.11-1, it now uses python3.