### PR TITLE
Add QT for GUI version of umbrel-details

### DIFF
--- a/stage2/03-install-umbrel/00-packages
+++ b/stage2/03-install-umbrel/00-packages
@@ -2,3 +2,4 @@ git
 fswatch
 jq
 python3-qrcode
+libqt5gui5 libqt5svg5 libqt5network5


### PR DESCRIPTION
Only merge this if you want to have that GUI version in Umbrel. When this PR is merged, the new GUI can be added by a PR in Umbrel.
Source code of the GUI: https://github.com/AaronDewes/umbrel-details-gui

It would look like this: (example.com is the tor URL, screenshot wasn't created on Umbrel OS, so I put example.com in the file for the tor address)
![example](https://user-images.githubusercontent.com/67546953/94723312-d629c880-0358-11eb-89c7-d447221a2971.png)
