### PR TITLE
Latest pi gen

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -170,6 +170,7 @@ export WPA_ESSID
 export WPA_PASSWORD
 export WPA_COUNTRY
 export ENABLE_SSH="${ENABLE_SSH:-1}"
+export PUBKEY_ONLY_SSH="${PUBKEY_ONLY_SSH:-0}"
 
 export LOCALE_DEFAULT="${LOCALE_DEFAULT:-en_GB.UTF-8}"
 
@@ -179,6 +180,8 @@ export KEYBOARD_LAYOUT="${KEYBOARD_LAYOUT:-English (UK)}"
 export TIMEZONE_DEFAULT="${TIMEZONE_DEFAULT:-Europe/London}"
 
 export GIT_HASH=${GIT_HASH:-"$(git rev-parse HEAD)"}
+
+export PUBKEY_SSH_FIRST_USER
 
 export CLEAN
 export IMG_NAME
@@ -226,6 +229,11 @@ fi
 
 if [[ -n "${WPA_PASSWORD}" && ${#WPA_PASSWORD} -lt 8 || ${#WPA_PASSWORD} -gt 63  ]] ; then
 	echo "WPA_PASSWORD" must be between 8 and 63 characters
+	exit 1
+fi
+
+if [[ "${PUBKEY_ONLY_SSH}" = "1" && -z "${PUBKEY_SSH_FIRST_USER}" && -z ${GITHUB_USERNAME} ]]; then
+	echo "Must set 'PUBKEY_SSH_FIRST_USER' to a valid SSH public key or 'GITHUB_USERNAME' if using PUBKEY_ONLY_SSH"
 	exit 1
 fi
 

--- a/export-image/prerun.sh
+++ b/export-image/prerun.sh
@@ -39,8 +39,32 @@ BOOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^1:' | cut -d':' -f 4 | tr -d B)
 ROOT_OFFSET=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 2 | tr -d B)
 ROOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 4 | tr -d B)
 
-BOOT_DEV=$(losetup --show -f -o "${BOOT_OFFSET}" --sizelimit "${BOOT_LENGTH}" "${IMG_FILE}")
-ROOT_DEV=$(losetup --show -f -o "${ROOT_OFFSET}" --sizelimit "${ROOT_LENGTH}" "${IMG_FILE}")
+echo "Mounting BOOT_DEV..."
+cnt=0
+until BOOT_DEV=$(losetup --show -f -o "${BOOT_OFFSET}" --sizelimit "${BOOT_LENGTH}" "${IMG_FILE}"); do
+	if [ $cnt -lt 5 ]; then
+		cnt=$((cnt + 1))
+		echo "Error in losetup for BOOT_DEV.  Retrying..."
+		sleep 5
+	else
+		echo "ERROR: losetup for BOOT_DEV failed; exiting"
+		exit 1
+	fi
+done
+
+echo "Mounting ROOT_DEV..."
+cnt=0
+until ROOT_DEV=$(losetup --show -f -o "${ROOT_OFFSET}" --sizelimit "${ROOT_LENGTH}" "${IMG_FILE}"); do
+	if [ $cnt -lt 5 ]; then
+		cnt=$((cnt + 1))
+		echo "Error in losetup for ROOT_DEV.  Retrying..."
+		sleep 5
+	else
+		echo "ERROR: losetup for ROOT_DEV failed; exiting"
+		exit 1
+	fi
+done
+
 echo "/boot: offset $BOOT_OFFSET, length $BOOT_LENGTH"
 echo "/:     offset $ROOT_OFFSET, length $ROOT_LENGTH"
 

--- a/export-noobs/prerun.sh
+++ b/export-noobs/prerun.sh
@@ -16,8 +16,32 @@ BOOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^1:' | cut -d':' -f 4 | tr -d B)
 ROOT_OFFSET=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 2 | tr -d B)
 ROOT_LENGTH=$(echo "$PARTED_OUT" | grep -e '^2:' | cut -d':' -f 4 | tr -d B)
 
-BOOT_DEV=$(losetup --show -f -o "${BOOT_OFFSET}" --sizelimit "${BOOT_LENGTH}" "${IMG_FILE}")
-ROOT_DEV=$(losetup --show -f -o "${ROOT_OFFSET}" --sizelimit "${ROOT_LENGTH}" "${IMG_FILE}")
+echo "Mounting BOOT_DEV..."
+cnt=0
+until BOOT_DEV=$(losetup --show -f -o "${BOOT_OFFSET}" --sizelimit "${BOOT_LENGTH}" "${IMG_FILE}"); do
+	if [ $cnt -lt 5 ]; then
+		cnt=$((cnt + 1))
+		echo "Error in losetup for BOOT_DEV.  Retrying..."
+		sleep 5
+	else
+		echo "ERROR: losetup for BOOT_DEV failed; exiting"
+		exit 1
+	fi
+done
+
+echo "Mounting ROOT_DEV..."
+cnt=0
+until ROOT_DEV=$(losetup --show -f -o "${ROOT_OFFSET}" --sizelimit "${ROOT_LENGTH}" "${IMG_FILE}"); do
+	if [ $cnt -lt 5 ]; then
+		cnt=$((cnt + 1))
+		echo "Error in losetup for ROOT_DEV.  Retrying..."
+		sleep 5
+	else
+		echo "ERROR: losetup for ROOT_DEV failed; exiting"
+		exit 1
+	fi
+done
+
 echo "/boot: offset $BOOT_OFFSET, length $BOOT_LENGTH"
 echo "/:     offset $ROOT_OFFSET, length $ROOT_LENGTH"
 

--- a/stage2/01-net-tweaks/01-run.sh
+++ b/stage2/01-net-tweaks/01-run.sh
@@ -27,7 +27,12 @@ network={
 EOL
 fi
 
-# Disable wifi on 5GHz models
+# Disable wifi on 5GHz models if WPA_COUNTRY is not set
 mkdir -p "${ROOTFS_DIR}/var/lib/systemd/rfkill/"
-echo 1 > "${ROOTFS_DIR}/var/lib/systemd/rfkill/platform-3f300000.mmc:wlan"
-echo 1 > "${ROOTFS_DIR}/var/lib/systemd/rfkill/platform-fe300000.mmc:wlan"
+if [ -n "$WPA_COUNTRY" ]; then
+    echo 0 > "${ROOTFS_DIR}/var/lib/systemd/rfkill/platform-3f300000.mmcnr:wlan"
+    echo 0 > "${ROOTFS_DIR}/var/lib/systemd/rfkill/platform-fe300000.mmcnr:wlan"
+else
+    echo 1 > "${ROOTFS_DIR}/var/lib/systemd/rfkill/platform-3f300000.mmcnr:wlan"
+    echo 1 > "${ROOTFS_DIR}/var/lib/systemd/rfkill/platform-fe300000.mmcnr:wlan"
+fi


### PR DESCRIPTION
This updates Umbrel to the latest pi-gen. Changes cherry-picked from the cherry-picks at [my fork with desktop](https://github.com/UmbrelOS-Tweaks/desktop). 

Improvements:
- Improved configuration options for SSH
- Only disable WiFi if WPA_COUNTRY is not set
- Fix build failure on AWS M6g instances
- Add printing support
- Fix permissions of the SSH folder if using a `GITHUB_USERNAME` (This is actually a bug in Umbrel OS which caused the ssh folder to be owned by root)