### PR TITLE
Update build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Umbrel OS](https://static.getumbrel.com/github/github-banner-umbrel-os.svg)](https://github.com/getumbrel/umbrel-os)
 
 [![Version](https://img.shields.io/github/v/release/getumbrel/umbrel-os?color=%235351FB&label=version)](https://github.com/getumbrel/umbrel-os/releases)
-[![Docker Build](https://img.shields.io/github/workflow/status/getumbrel/umbrel-os/Run%20Release%20Script%20on%20push%20to%20MASTER?color=%235351FB)](https://github.com/getumbrel/umbrel-os/actions?query=workflow%3A"Run+Release+Script+on+push+to+MASTER")
+[![Automated builds](https://img.shields.io/github/workflow/status/getumbrel/umbrel-os/Build%20image%20on%20push%20or%20PR?color=%235351FB)](https://github.com/getumbrel/umbrel-os/actions?query=workflow%3A"Build+image+on+push+or+PR")
 [![Community Chat](https://img.shields.io/badge/community%20chat-telegram-%235351FB)](https://t.me/getumbrel)
 [![Developer Chat](https://img.shields.io/badge/dev%20chat-keybase-%235351FB)](https://keybase.io/team/getumbrel)
 


### PR DESCRIPTION
Before this PR, it referenced an older workflow, causing the badge to always fetch the data from that workflow. In addition, it was called "Docker build", I now renamed it to "automated builds" becuase Umbrel OS is no docker container