### PR TITLE
Less packages

### DIFF
--- a/stage2/00-sys-tweaks/00-packages
+++ b/stage2/00-sys-tweaks/00-packages
@@ -5,11 +5,9 @@ avahi-daemon
 hardlink ca-certificates curl
 fake-hwclock usbutils
 dosfstools
-pi-bluetooth
 apt-listchanges
 usb-modeswitch
 libpam-chksshpwd
-rpi-update
 rsync
 htop
 man-db
@@ -17,7 +15,4 @@ policykit-1
 ssh-import-id
 rng-tools
 ethtool
-vl805fw
-ntfs-3g
 pciutils
-rpi-eeprom

--- a/stage2/00-sys-tweaks/01-run.sh
+++ b/stage2/00-sys-tweaks/01-run.sh
@@ -6,6 +6,7 @@ install -m 755 files/resize2fs_once	"${ROOTFS_DIR}/etc/init.d/"
 
 install -d				"${ROOTFS_DIR}/etc/systemd/system/rc-local.service.d"
 install -m 644 files/ttyoutput.conf	"${ROOTFS_DIR}/etc/systemd/system/rc-local.service.d/"
+install -m 644 files/regenerate_ssh_host_keys.service	"${ROOTFS_DIR}/etc/systemd/system/"
 
 install -m 644 files/50raspi		"${ROOTFS_DIR}/etc/apt/apt.conf.d/"
 

--- a/stage2/00-sys-tweaks/files/regenerate_ssh_host_keys.service
+++ b/stage2/00-sys-tweaks/files/regenerate_ssh_host_keys.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Regenerate SSH host keys
+Before=ssh.service
+ConditionFileIsExecutable=/usr/bin/ssh-keygen
+
+[Service]
+Type=oneshot
+ExecStartPre=-/bin/dd if=/dev/hwrng of=/dev/urandom count=1 bs=4096
+ExecStartPre=-/bin/sh -c "/bin/rm -f -v /etc/ssh/ssh_host_*_key*"
+ExecStart=/usr/bin/ssh-keygen -A -v
+ExecStartPost=/bin/systemctl disable regenerate_ssh_host_keys
+
+[Install]
+WantedBy=multi-user.target

--- a/stage2/01-net-tweaks/00-packages
+++ b/stage2/01-net-tweaks/00-packages
@@ -1,5 +1,4 @@
 wpasupplicant wireless-tools firmware-atheros firmware-brcm80211 firmware-libertas firmware-misc-nonfree firmware-realtek
-raspberrypi-net-mods
 dhcpcd5
 net-tools
 libzbar-dev

--- a/stage2/01-net-tweaks/00-packages
+++ b/stage2/01-net-tweaks/00-packages
@@ -1,4 +1,4 @@
-wpasupplicant wireless-tools firmware-atheros firmware-brcm80211 firmware-libertas firmware-misc-nonfree firmware-realtek
+wpasupplicant wireless-tools firmware-brcm80211
 dhcpcd5
 net-tools
 libzbar-dev


### PR DESCRIPTION
This makes migration to a pure debian base easier, as it removes most of the RPi packages we don't need (We only need 2 for the boot firmware & kernel and another one that is also part of debian with WLAN firmware)

- pi-bluetooth: We don't need bluetooth
- rpi-update: Allows manual kernel updates from CLI, not needed
- vl805fw, rpi-eeprom: Provides updates for RPi EEPROM firmware, we don't need autoupdates for that
- ntfs-3g: We don't need NTFS support
- raspberrypi-net-mods: Only prints an error message if WLAN is disabled, no other functionality
- firmware-* a few non-free firmware packages we don't need in Umbrel, removing more non-free components (my goal is to make as much of the OS base free as possible)

I'm planning on removing even more packages in the future, but these are the ones that are in my opionion  the most "useless" for our Umbrel.