### PR TITLE
Replace Google's DNS with Cloudflare

### DIFF
--- a/export-image/02-network/files/resolv.conf
+++ b/export-image/02-network/files/resolv.conf
@@ -1,1 +1,2 @@
-nameserver 8.8.8.8
+nameserver 1.1.1.1
+nameserver 1.0.0.1


### PR DESCRIPTION
Given the nature of this project, opting for Cloudflare's privacy-first 1.1.1.1 (1.0.0.1) DNS [0] above Google's seems reasonable.

Additionally, per DNSPerf, 1.1.1.1, is significantly faster than Google's [1].

[0] https://1.1.1.1/dns/
[1] https://www.dnsperf.com/#!dns-resolvers