### PR TITLE
Ensure SSH keys are generated from hwrng

### DIFF
--- a/stage2/00-sys-tweaks/00-packages
+++ b/stage2/00-sys-tweaks/00-packages
@@ -21,3 +21,4 @@ vl805fw
 ntfs-3g
 pciutils
 rpi-eeprom
+libcap2-bin gettext-base

--- a/stage2/00-sys-tweaks/01-run.sh
+++ b/stage2/00-sys-tweaks/01-run.sh
@@ -6,6 +6,7 @@ install -m 755 files/resize2fs_once	"${ROOTFS_DIR}/etc/init.d/"
 
 install -d				"${ROOTFS_DIR}/etc/systemd/system/rc-local.service.d"
 install -m 644 files/ttyoutput.conf	"${ROOTFS_DIR}/etc/systemd/system/rc-local.service.d/"
+install -m 644 files/regenerate_ssh_host_keys.service	"${ROOTFS_DIR}/etc/systemd/system/"
 
 install -m 644 files/50raspi		"${ROOTFS_DIR}/etc/apt/apt.conf.d/"
 

--- a/stage2/00-sys-tweaks/files/regenerate_ssh_host_keys.service
+++ b/stage2/00-sys-tweaks/files/regenerate_ssh_host_keys.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Regenerate SSH host keys
+Before=ssh.service
+ConditionFileIsExecutable=/usr/bin/ssh-keygen
+
+[Service]
+Type=oneshot
+ExecStartPre=-/bin/dd if=/dev/hwrng of=/dev/urandom count=1 bs=4096
+ExecStartPre=-/bin/sh -c "/bin/rm -f -v /etc/ssh/ssh_host_*_key*"
+ExecStart=/usr/bin/ssh-keygen -A -v
+ExecStartPost=/bin/systemctl disable regenerate_ssh_host_keys
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
They were in the previous release but aren't currently in master since removing the raspberrypi-sys-mods package (https://github.com/getumbrel/umbrel-os/pull/167).