### PR TITLE
Disable UAS for a SATA interface.

### DIFF
--- a/stage1/00-boot-files/files/cmdline.txt
+++ b/stage1/00-boot-files/files/cmdline.txt
@@ -1,1 +1,1 @@
-usb-storage.quirks=152d:1561:u,152d:1576:u,152d:0578:u,125f:a76a:u,04e8:61b6:u console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait
+usb-storage.quirks=152d:1561:u,152d:1576:u,152d:0578:u,125f:a76a:u,04e8:61b6:u,152d:0562:u console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait


### PR DESCRIPTION
Hi. I bought this particular case that wasn't working on the USB3 interface.

https://www.amazon.es/dp/B077XVTTJC/?coliid=I2A06MFLQUYY95&colid=1QF557D5V5LOG

After adding the idVendor and idProduct to this list it started working. 

I believe there might be countless people with this particular problem. Specially international users that can't find the particular recommended umbrel hardware.