### PR TITLE
Disable bluetooth to reduce power consumption

### DIFF
--- a/stage1/00-boot-files/files/config.txt
+++ b/stage1/00-boot-files/files/config.txt
@@ -61,3 +61,6 @@ dtoverlay=vc4-fkms-v3d
 max_framebuffers=2
 
 arm_64bit=1
+
+# Disable Bluetooth
+dtoverlay=disable-bt


### PR DESCRIPTION
As we've discussed before, this PR disables Bluetooth to try to reduce power consumption.