### PR TITLE
Remove elevator=deadline from cmdline.txt

### DIFF
--- a/stage1/00-boot-files/files/cmdline.txt
+++ b/stage1/00-boot-files/files/cmdline.txt
@@ -1,1 +1,1 @@
-usb-storage.quirks=152d:1561:u,152d:1576:u,152d:0578:u console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait
+usb-storage.quirks=152d:1561:u,152d:1576:u,152d:0578:u console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 fsck.repair=yes rootwait

--- a/stage2/00-sys-tweaks/00-patches/07-resize-init.diff
+++ b/stage2/00-sys-tweaks/00-patches/07-resize-init.diff
@@ -1,5 +1,5 @@
 --- stage2.orig/rootfs/boot/cmdline.txt
 +++ stage2/rootfs/boot/cmdline.txt
 @@ -1 +1 @@
--usb-storage.quirks=152d:1561:u,152d:1576:u,152d:0578:u console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait
-+usb-storage.quirks=152d:1561:u,152d:1576:u,152d:0578:u console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait quiet init=/usr/lib/raspi-config/init_resize.sh
+-usb-storage.quirks=152d:1561:u,152d:1576:u,152d:0578:u console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 fsck.repair=yes rootwait
++usb-storage.quirks=152d:1561:u,152d:1576:u,152d:0578:u console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 fsck.repair=yes rootwait quiet init=/usr/lib/raspi-config/init_resize.sh


### PR DESCRIPTION
This does nothing on recent kernels (except logging a warning that this doesn't work anymore).
