### PR TITLE
Add example SSH command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ SSH is enabled by default and you can use the following credentials to login to 
 - Hostname: `umbrel.local`  
 - User: `umbrel`  
 - Password: The same password you use to log in to the Umbrel dashboard
+
+```bash
+ssh umbrel@umbrel.local
+```
  
 > If you haven't yet run through the setup process, the password will be set to `moneyprintergobrrr`.
 


### PR DESCRIPTION
It's helpful having command to copy paste, and makes this a little more beginner-friendly, if users are getting up to speed with  their raspberry pi. 